### PR TITLE
Fix non-existent errno raised in open_resource

### DIFF
--- a/pluginbase.py
+++ b/pluginbase.py
@@ -292,7 +292,7 @@ class PluginSource(object):
                 return open(os.path.join(os.path.dirname(fn), filename), 'rb')
         buf = pkgutil.get_data(self.mod.__name__ + '.' + plugin, filename)
         if buf is None:
-            raise IOError(errno.ENOEXITS, 'Could not find resource')
+            raise IOError(errno.ENOENT, 'Could not find resource')
         return NativeBytesIO(buf)
 
     def cleanup(self):


### PR DESCRIPTION
I think the intention was to raise ENOEXIST - and while I see references to that errno in a google search, the standard errno in this case is ENOENT.