### PR TITLE
Fix #6, check key exists before removing

### DIFF
--- a/pluginbase.py
+++ b/pluginbase.py
@@ -316,7 +316,9 @@ class PluginSource(object):
         except AttributeError:
             pass
         prefix = modname + '.'
-        _sys.modules.pop(modname)
+        # avoid the bug described in issue #6
+        if modname in _sys.modules:
+            del _sys.modules[modname]
         for key, value in list(_sys.modules.items()):
             if not key.startswith(prefix):
                 continue


### PR DESCRIPTION
This change fixes the issue described in #6 by checking that the key exists in `_sys.modules` before trying to delete it.