### PR TITLE
get_searchpath function corrected for recursive directories retrieval

### DIFF
--- a/pluginbase.py
+++ b/pluginbase.py
@@ -92,13 +92,13 @@ def get_searchpath(path, depth=float('inf'), followlinks=False):
     # slow execution when *path* is a large tree and *depth* is a small number
     paths = [path]
     for dir_entry in os.listdir(path):
-        path = os.path.join(path, dir_entry)
-        if not os.path.isdir(path):
+        sub_path = os.path.join(path, dir_entry)
+        if not os.path.isdir(sub_path):
             continue
-        if not followlinks and os.path.islink(path):
+        if not followlinks and os.path.islink(sub_path):
             continue
         if depth:
-            paths.extend(get_searchpath(path, depth - 1, followlinks))
+            paths.extend(get_searchpath(sub_path, depth - 1, followlinks))
     return paths
 
 


### PR DESCRIPTION
get_searchpath method(in pluginbase.py) is not returning all the sub-directories in the given path.This fix gives the subdirectories as well.
For example , for the below directory structure, the current code in get_searchpath is not returning all the sub-directories.
app1
  - app2
       -test2.py
  - test1.py
app3
   -app4
      - test4.py
   - test3.py

It has been fixed in this commit.